### PR TITLE
Comment Images Overlap Other Comments

### DIFF
--- a/style-2.css
+++ b/style-2.css
@@ -347,17 +347,21 @@ tr:hover {
 }
 
 .review-author p {
-  padding: .2em;
+  padding: 0em .5em;
 }
 
 .review-rating {
-  width: 120px;
+  display: inline-block;
+}
+
+.review-comment {
+  display: inline-block;
 }
 
 .review-comment img {
   float: right;
   width: 50%;
-  margin: 0px 20px;
+  margin: 10px 20px;
 }
 
 .review-comment p {


### PR DESCRIPTION
Fixes #4 by adjusting the CSS to accommodate the image better.

![image](https://github.com/14ercooper/ctm_repository/assets/21300678/55d2b726-4976-49d0-929c-206dab390a07)
