### PR TITLE
Confirmation Box When Reporting A Comment

### DIFF
--- a/templates/browseComments.php
+++ b/templates/browseComments.php
@@ -2,6 +2,17 @@
 
 <h1>Comments For <?php echo $dispMap->name ?></h1>
 
+<script type="text/javascript">
+    function confirmReport(id) {
+        if (confirm('Would you like to report this comment?')) {
+            window.location.href = "index.php?action=reportComment&id=<?php echo $dispMap->id ?>&commentId=" + id;
+        }
+        else {
+            window.location.href = "index.php?action=viewComments&id=<?php echo $dispMap->id ?>";
+        }
+    }
+</script>
+
 <div class="reviewContainer">
     <?php if (!is_null($dispMap->comments)) foreach ($dispMap->comments as $comment) { ?>
         <?php include $_SERVER['DOCUMENT_ROOT'] . "/templates/comment.php" ?>

--- a/templates/comment.php
+++ b/templates/comment.php
@@ -20,7 +20,7 @@
     </div>
     <div>
         <?php if (!isset($_GET['status']) && !isset($_GET['commentId']) || isset($_GET['commentId']) && $_GET['commentId'] != $comment->id) { ?>
-            <a href="index.php?action=reportComment&id=<?php echo $comment->parentMapId ?>&commentId=<?php echo $comment->id ?>"><p class="report">Report Comment</p></a>
+            <a href="#" onclick="confirmReport(<?php echo $comment->id ?>)"><p class="report">Report Comment</p></a>
         <?php } ?>
     </div>
 </div>

--- a/templates/viewMap.php
+++ b/templates/viewMap.php
@@ -19,6 +19,17 @@
 	<div class="statusMessage">Thank you for reporting this comment. We will continue to monitor this comment for more reports. Please continue to keep our community safe!</div>
 <?php } } ?>
 
+<script type="text/javascript">
+    function confirmReport(id) {
+        if (confirm('Would you like to report this comment?')) {
+            window.location.href = "index.php?action=reportComment&id=<?php echo $dispMap->id ?>&commentId=" + id;
+        }
+        else {
+            window.location.href = "index.php?action=viewMap&id=<?php echo $dispMap->id ?>";
+        }
+    }
+</script>
+
 <div class="mapView">
 	<img src="<?php echo $dispMap->imageURL ?>" alt="Map thumbnail" style="float:left;width:100%;"/><hr style="height:15pt; visibility:hidden;" />
 	<br><br>


### PR DESCRIPTION
Fixes #6 by showing a confirmation box before reporting a comment. If okayed, proceeds to report the comment. Otherwise, will return back to the map page or comments list.

![image](https://github.com/14ercooper/ctm_repository/assets/21300678/66195f3d-3707-4307-82e5-2f058fabb13a)
