### PR TITLE
Fix search trying to limit results by map name

### DIFF
--- a/classes/map.php
+++ b/classes/map.php
@@ -269,7 +269,7 @@ class Map {
 		// Place returned maps into an array
 		$list = array();
 		while ($row = $st->fetch()) {
-			$map = new Map($row);
+			$map = new Map($row, $commentLimit);
 			$list[] = $map;
 		}
 

--- a/search.php
+++ b/search.php
@@ -41,7 +41,7 @@ function results () {
 	elseif ($_POST['type'] === "Other") { $mapType = "Other"; }
 
 	// Load maps
-	$data = Map::getList($numRows, $order, $mapName, $mapAuthor, $mapDifficulty, $mapLength, $mapSeries, $mapType, $mapObjectives);
+	$data = Map::getList($numRows, 0, $order, $mapName, $mapAuthor, $mapDifficulty, $mapLength, $mapSeries, $mapType, $mapObjectives);
 	$results['maps'] = $data['results'];
 	$results['pageTitle'] = "Search | CTM Map Repository";
 


### PR DESCRIPTION
Fixes #9 by inputting the proper parameters when getting the list. In this case, if you searched for a map by its name, it was trying to limit results by the map name, which is completely invalid SQL.

In addition, it adds the comment limit in as a parameter when constructing a map in getList, so it is respected when it is passed in.