### PR TITLE
Automated Deployment Pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   build-artifacts:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true || ${{ env.ACT }}
     steps:
       - run: echo ${{github.workspace}}
       - run: mkdir -p ${{github.workspace}}/ctmrepo-${{github.run_id}}.${{github.run_number}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,21 @@
+name: Deploy
+
+on:
+  pull_request:
+    types: closed
+
+jobs:
+  build-artifacts:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - run: echo ${{github.workspace}}
+      - run: mkdir -p ${{github.workspace}}/ctmrepo-${{github.run_id}}.${{github.run_number}}
+      - run: cd ${{github.workspace}}/ctmrepo-${{github.run_id}}.${{github.run_number}}
+      - run: git clone ${{github.server_url}}/${{github.repository}}.git
+      - run: cd ..
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ctmrepo-${{github.run_id}}.${{github.run_number}}
+          path: ${{github.workspace}}/ctmrepo-${{github.run_id}}.${{github.run_number}}/ctm_repository/
+        

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,16 +1,24 @@
 name: Deploy
 
 env:
-  version-major: 1
-  version-minor: 1
-  # This is here for testing locally, should default to true
-  upload-artifact: 'true'
-  download-artifact: 'true'
+  version: ${{github.event.inputs.version-major}}.${{github.event.inputs.version-minor}}.${{github.event.inputs.version-patch}}${{github.event.inputs.version-metadata}}
 
 on:
-  pull_request:
-    types: closed
-  push:
+  workflow_dispatch:
+    inputs:
+      version-major:
+        description: Define major build version
+        required: true
+      version-minor:
+        description: Define minor build version
+        required: true
+      version-patch:
+        description: Define patch build version
+        required: true
+      version-metadata:
+        description: Define additional metadata for build version
+        required: false
+        default: ''
 
 jobs:
   build-artifacts:
@@ -18,21 +26,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          path: ./ctmrepo-${{env.version-major}}.${{env.version-minor}}
+          path: ./ctmrepo-${{env.version}}
       - uses: actions/upload-artifact@v4
         with:
-          name: ctmrepo-${{env.version-major}}.${{env.version-minor}}
+          name: ctmrepo-${{env.version}}
           path: | 
-                ./ctmrepo-${{env.version-major}}.${{env.version-minor}}/
-                !./ctmrepo-${{env.version-major}}.${{env.version-minor}}/.git/*
-                !./ctmrepo-${{env.version-major}}.${{env.version-minor}}/vendor/*
+                ./ctmrepo-${{env.version}}/
+                !./ctmrepo-${{env.version}}/.git/*
+                !./ctmrepo-${{env.version}}/vendor/*
   deploy-artifacts:
     runs-on: ubuntu-latest
     needs: build-artifacts
     steps:
       - uses: actions/download-artifact@v4    
         with:
-          name: ctmrepo-${{env.version-major}}.${{env.version-minor}}
+          name: ctmrepo-$ctmrepo-${{env.version}}
           path: artifacts
       - run: ls -R artifacts
       - uses: Creepios/sftp-action@v1.0.5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,5 +35,14 @@ jobs:
           name: ctmrepo-${{env.version-major}}.${{env.version-minor}}
           path: artifacts
       - run: ls -R artifacts
+      - uses: Creepios/sftp-action@v1.0.5
+        with:
+          host: ${{secrets.SERVER_IP}}
+          username: ${{secrets.SERVER_USER}}
+          password: ${{secrets.SERVER_PASSWORD}}
+          port: 22
+          localPath: artifacts/
+          remotePath: data/
+
                 
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
           password: ${{secrets.SERVER_PASSWORD}}
           port: 22
           localPath: artifacts/
-          remotePath: data/
+          remotePath: ${{vars.DEPLOYMENT_PATH}}
 
                 
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
                 !./ctmrepo-${{env.version-major}}.${{env.version-minor}}/vendor/*
   deploy-artifacts:
     runs-on: ubuntu-latest
+    needs: build-artifacts
     steps:
       - uses: actions/download-artifact@v4    
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          path: /ctmrepo-${{github.run_id}}.${{github.run_number}}/
+          path: ./ctmrepo-${{github.run_id}}.${{github.run_number}}/
       - uses: actions/upload-artifact@v4
         with:
           name: ctmrepo-${{github.run_id}}.${{github.run_number}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,8 @@ env:
   version-major: 1
   version-minor: 1
   # This is here for testing locally, should default to true
-  upload-artifact: true
-  download-artifact: true
+  upload-artifact: 'true'
+  download-artifact: 'true'
 
 on:
   pull_request:
@@ -15,20 +15,23 @@ on:
 jobs:
   build-artifacts:
     runs-on: ubuntu-latest
+    if: ${{ env.upload-artifact == 'true' }}
     steps:
       - uses: actions/checkout@v4
         with:
           path: ./ctmrepo-${{env.version-major}}.${{env.version-minor}}
       - uses: actions/upload-artifact@v4
-        if: ${{ env.upload-artifact == true }}
         with:
           name: ctmrepo-${{env.version-major}}.${{env.version-minor}}
           path: | 
                 ./ctmrepo-${{env.version-major}}.${{env.version-minor}}/
                 !./ctmrepo-${{env.version-major}}.${{env.version-minor}}/.git/*
                 !./ctmrepo-${{env.version-major}}.${{env.version-minor}}/vendor/*
-      - uses: actions/download-artifact@v4
-        if: ${{ env.download-artifact == true }}
+  deploy-artifacts:
+    runs-on: ubuntu-latest
+    if: ${{ env.download-artifact == 'true' }}
+    steps:
+      - uses: actions/download-artifact@v4    
         with:
           name: ctmrepo-${{env.version-major}}.${{env.version-minor}}
           path: artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,11 +3,12 @@ name: Deploy
 on:
   pull_request:
     types: closed
+  push:
 
 jobs:
   build-artifacts:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true || env.ACT
     steps:
       - run: echo ${{github.workspace}}
       - run: mkdir -p ${{github.workspace}}/ctmrepo-${{github.run_id}}.${{github.run_number}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ on:
         required: true
       version-metadata:
         description: Define additional metadata for build version
-        required: false
         default: ''
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,11 @@
 name: Deploy
 
+env:
+  version-major: 1
+  version-minor: 1
+  # This is here for testing locally, will be overridden when ran in Github.
+  ACT: false
+
 on:
   pull_request:
     types: closed
@@ -11,12 +17,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          path: ./ctmrepo-${{github.run_id}}.${{github.run_number}}/
+          path: ./ctmrepo-${{env.version-major}}.${{env.version-minor}}
       - uses: actions/upload-artifact@v4
+        if: ${{ !env.ACT }}
         with:
-          name: ctmrepo-${{github.run_id}}.${{github.run_number}}
+          name: ctmrepo-${{env.version-major}}.${{env.version-minor}}
           path: | 
-                ./ctmrepo-${{github.run_id}}.${{github.run_number}}/
-                !./ctmrepo-${{github.run_id}}.${{github.run_number}}/.git/*
+                ./ctmrepo-${{env.version-major}}.${{env.version-minor}}/
+                !./ctmrepo-${{env.version-major}}.${{env.version-minor}}/.git/*
+                !./ctmrepo-${{env.version-major}}.${{env.version-minor}}/vendor/*
+      - uses: actions/download-artifact@v4
+        if: ${{ !env.ACT }}
+        with:
+          name: ctmrepo-${{env.version-major}}.${{env.version-minor}}
                 
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-artifacts:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true || env.ACT
+    if: github.event.pull_request.merged == true || ${{ env.ACT }}
     steps:
       - run: echo ${{github.workspace}}
       - run: mkdir -p ${{github.workspace}}/ctmrepo-${{github.run_id}}.${{github.run_number}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,13 +9,14 @@ jobs:
   build-artifacts:
     runs-on: ubuntu-latest
     steps:
-      - run: echo ${{github.workspace}}
-      - run: mkdir -p ${{github.workspace}}/ctmrepo-${{github.run_id}}.${{github.run_number}}
-      - run: cd ${{github.workspace}}/ctmrepo-${{github.run_id}}.${{github.run_number}}
-      - run: git clone ${{github.server_url}}/${{github.repository}}.git
-      - run: cd ..
+      - uses: actions/checkout@v4
+        with:
+          path: /ctmrepo-${{github.run_id}}.${{github.run_number}}/
       - uses: actions/upload-artifact@v4
         with:
           name: ctmrepo-${{github.run_id}}.${{github.run_number}}
-          path: ${{github.workspace}}/ctmrepo-${{github.run_id}}.${{github.run_number}}/ctm_repository/
+          path: | 
+                ./ctmrepo-${{github.run_id}}.${{github.run_number}}/
+                !./ctmrepo-${{github.run_id}}.${{github.run_number}}/.git/*
+                
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,9 @@ name: Deploy
 env:
   version-major: 1
   version-minor: 1
-  # This is here for testing locally, will be overridden when ran in Github.
-  ACT: false
+  # This is here for testing locally, should default to true
+  upload-artifact: true
+  download-artifact: true
 
 on:
   pull_request:
@@ -19,7 +20,7 @@ jobs:
         with:
           path: ./ctmrepo-${{env.version-major}}.${{env.version-minor}}
       - uses: actions/upload-artifact@v4
-        if: ${{ !env.ACT }}
+        if: ${{ env.upload-artifact == true }}
         with:
           name: ctmrepo-${{env.version-major}}.${{env.version-minor}}
           path: | 
@@ -27,8 +28,10 @@ jobs:
                 !./ctmrepo-${{env.version-major}}.${{env.version-minor}}/.git/*
                 !./ctmrepo-${{env.version-major}}.${{env.version-minor}}/vendor/*
       - uses: actions/download-artifact@v4
-        if: ${{ !env.ACT }}
+        if: ${{ env.download-artifact == true }}
         with:
           name: ctmrepo-${{env.version-major}}.${{env.version-minor}}
+          path: artifacts
+      - run: ls -R artifacts
                 
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   build-artifacts:
     runs-on: ubuntu-latest
-    if: ${{ env.upload-artifact == 'true' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -29,7 +28,6 @@ jobs:
                 !./ctmrepo-${{env.version-major}}.${{env.version-minor}}/vendor/*
   deploy-artifacts:
     runs-on: ubuntu-latest
-    if: ${{ env.download-artifact == 'true' }}
     steps:
       - uses: actions/download-artifact@v4    
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4    
         with:
-          name: ctmrepo-$ctmrepo-${{env.version}}
+          name: ctmrepo-${{env.version}}
           path: artifacts
       - run: ls -R artifacts
       - uses: Creepios/sftp-action@v1.0.5

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 config.php
 map_img/
 classes/14erAuth.php
+*.env
 


### PR DESCRIPTION
This PR aims to add a fully automated deployment pipeline to the repository for storing past builds as well as automatically deploying them to the server via SFTP using Github Actions.

In order to use it, you'll need a few things set up in the repository settings, under Secrets and Variables > Actions:
* A variable for where the deployment deploys all the files named DEPLOYMENT_PATH
* A secret for the SFTP Server IP named SERVER_IP
* A secret for the SFTP User Name named SERVER_USER
* A secret for the SFTP User Password named SERVER_PASSWORD

Once configured and merged into master, this should allow you to trigger a deployment which will ask for version numbers (using SemVer + any additional metadata), and once passed in, will:
* Checkout master on a Unix machine
* Upload the files as a build
* Download the build on a new Unix machine
* SFTP the build to a specified folder on a specified server

