### PR TITLE
Fix logo padding causing overflow and scroll on body

### DIFF
--- a/style-2.css
+++ b/style-2.css
@@ -24,7 +24,7 @@ body {
 #logo {
   display: block;
   width: 300px;
-  padding: 0 660px 20px 0;
+  padding: 0 0 20px 0;
   border: none;
   border-bottom: 1px solid #DCDCDC;
 }


### PR DESCRIPTION
The padding on the logo causes overflow and scroll on the body of the page. This happens at 1080p resolution, but I think it doesn't occur at higher resolutions.

Here's the padding in question.

<img width="1683" height="578" alt="image" src="https://github.com/user-attachments/assets/5185a9c2-857b-4961-acd4-84ed1136116c" />

This was bothering me and I figured out it was a quick fix.

Thanks for the great website!